### PR TITLE
Add Limit option to Locations

### DIFF
--- a/snipeit.go
+++ b/snipeit.go
@@ -135,6 +135,7 @@ func (c *Client) AddOptions(s string, opt interface{}) (string, error) {
 type LocationOptions struct {
 	// Search string
 	Search string `url:"search,omitempty"`
+	Limit int `url:"limit,omitempty"`
 }
 
 // Location represents a Snipe-IT location.

--- a/snipeit.go
+++ b/snipeit.go
@@ -135,7 +135,7 @@ func (c *Client) AddOptions(s string, opt interface{}) (string, error) {
 type LocationOptions struct {
 	// Search string
 	Search string `url:"search,omitempty"`
-	Limit int `url:"limit,omitempty"`
+	Limit  int    `url:"limit,omitempty"`
 }
 
 // Location represents a Snipe-IT location.


### PR DESCRIPTION
There is a default return limit of 50. With this option you can change this.