### PR TITLE
hardware: Company has "ID" and "Name" sub-fields

### DIFF
--- a/hardware.go
+++ b/hardware.go
@@ -51,7 +51,10 @@ type Hardware struct {
 	} `json:"supplier,omitempty"`
 	Notes       string    `json:"notes,omitempty"`
 	OrderNumber string    `json:"order_number,omitempty"`
-	Company     string    `json:"company,omitempty"`
+	Company     struct {
+		ID   int64  `json:"id,omitempty"`
+		Name string `json:"name,omitempty"`
+	}
 	Location    *Location `json:"location,omitempty"`
 	RtdLocation *Location `json:"rtd_location,omitempty"`
 	Image       string    `json:"image,omitempty"`

--- a/hardware.go
+++ b/hardware.go
@@ -49,8 +49,8 @@ type Hardware struct {
 		ID   int64  `json:"id,omitempty"`
 		Name string `json:"name,omitempty"`
 	} `json:"supplier,omitempty"`
-	Notes       string    `json:"notes,omitempty"`
-	OrderNumber string    `json:"order_number,omitempty"`
+	Notes       string `json:"notes,omitempty"`
+	OrderNumber string `json:"order_number,omitempty"`
 	Company     struct {
 		ID   int64  `json:"id,omitempty"`
 		Name string `json:"name,omitempty"`


### PR DESCRIPTION
This succeeds on tenants with no Companies defined, but fails with an error if a tenant does have Companies : 
`json: cannot unmarshal object into Go struct field Hardware.Rows.company of type string[]`